### PR TITLE
Safely exit `add_pkgdown-examples()` if no examples exist

### DIFF
--- a/R/add_pkgdown_examples.R
+++ b/R/add_pkgdown_examples.R
@@ -10,23 +10,25 @@
 #'   Default is `"_pkgdown.yml"`.
 #' @param rmd_dir Character. Path to directory containing example `\.Rmd` files
 #'   used to derive titles and order. Default is `"inst/examples"`.
+#' @param debug Logical. Whether to show debug messages. Default is `FALSE`.
 #'
 #' @returns `NULL` invisibly.
 #' @export
 add_pkgdown_examples <- function(
   examples_dir = "pkgdown/assets/examples",
   pkgdown_yml = "_pkgdown.yml",
-  rmd_dir = "inst/examples"
+  rmd_dir = "inst/examples",
+  debug = FALSE
 ) {
   rlang::check_installed("yaml", reason = "to manipulate _pkgdown.yml files.")
 
-  html_files <- list_non_index_html(examples_dir)
+  html_files <- list_non_index_html(examples_dir, debug = debug)
   metadata <- list_example_metadata(rmd_dir)
 
   if (length(html_files)) {
     update_pkgdown_examples(pkgdown_yml, html_files, metadata)
   } else {
-    remove_pkgdown_examples(pkgdown_yml, examples_dir)
+    remove_pkgdown_examples(pkgdown_yml, examples_dir, debug = debug)
   }
   invisible(NULL)
 }
@@ -34,24 +36,28 @@ add_pkgdown_examples <- function(
 #' List HTML files excluding index.html
 #'
 #' @param examples_dir Character. Path to directory containing example HTML files.
+#' @param debug Logical. Whether to show debug messages.
 #' @returns Character vector of HTML file names.
 #' @keywords internal
-list_non_index_html <- function(examples_dir) {
+list_non_index_html <- function(examples_dir, debug = FALSE) {
   if (is.null(examples_dir) || !fs::dir_exists(examples_dir)) {
-    cli::cli_warn("Examples directory {.path {examples_dir}} does not exist.")
     return(character())
   }
   
   html_files <- tryCatch(
     fs::path_file(fs::dir_ls(examples_dir, glob = "*.html")),
     error = function(e) {
-      cli::cli_warn("Error reading HTML files from {.path {examples_dir}}: {e$message}")
+      if (debug) {
+        cli::cli_inform("Could not read HTML files from {.path {examples_dir}}: {e$message}")
+      }
       character()
     }
   )
   
   if (length(html_files) == 0) {
-    cli::cli_warn("No HTML files found in {.path {examples_dir}}.")
+    if (debug) {
+      cli::cli_inform("No HTML files found in {.path {examples_dir}}.")
+    }
     return(character())
   }
   
@@ -132,10 +138,13 @@ add_pkgdown_examples_to_yaml <- function(pkgdown_yaml, html_files, metadata) {
 #'
 #' @param pkgdown_yml Character. Path to `_pkgdown.yml`.
 #' @param examples_dir Character. Path to examples directory.
+#' @param debug Logical. Whether to show debug messages.
 #' @returns `NULL` invisibly.
 #' @keywords internal
-remove_pkgdown_examples <- function(pkgdown_yml, examples_dir) {
-  cli::cli_inform("No HTML files found in {.path {examples_dir}}.")
+remove_pkgdown_examples <- function(pkgdown_yml, examples_dir, debug = FALSE) {
+  if (debug) {
+    cli::cli_inform("No HTML files found in {.path {examples_dir}}.")
+  }
   if (!is.null(pkgdown_yml) && fs::file_exists(pkgdown_yml)) {
     pkgdown_yaml <- yaml::read_yaml(pkgdown_yml)
     pkgdown_yaml$navbar$components$examples <- NULL

--- a/R/add_pkgdown_examples.R
+++ b/R/add_pkgdown_examples.R
@@ -37,7 +37,24 @@ add_pkgdown_examples <- function(
 #' @returns Character vector of HTML file names.
 #' @keywords internal
 list_non_index_html <- function(examples_dir) {
-  html_files <- fs::path_file(fs::dir_ls(examples_dir, glob = "*.html"))
+  if (is.null(examples_dir) || !fs::dir_exists(examples_dir)) {
+    cli::cli_warn("Examples directory {.path {examples_dir}} does not exist.")
+    return(character())
+  }
+  
+  html_files <- tryCatch(
+    fs::path_file(fs::dir_ls(examples_dir, glob = "*.html")),
+    error = function(e) {
+      cli::cli_warn("Error reading HTML files from {.path {examples_dir}}: {e$message}")
+      character()
+    }
+  )
+  
+  if (length(html_files) == 0) {
+    cli::cli_warn("No HTML files found in {.path {examples_dir}}.")
+    return(character())
+  }
+  
   html_files[html_files != "index.html"]
 }
 

--- a/man/add_pkgdown_examples.Rd
+++ b/man/add_pkgdown_examples.Rd
@@ -7,7 +7,8 @@
 add_pkgdown_examples(
   examples_dir = "pkgdown/assets/examples",
   pkgdown_yml = "_pkgdown.yml",
-  rmd_dir = "inst/examples"
+  rmd_dir = "inst/examples",
+  debug = FALSE
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ Default is \code{"_pkgdown.yml"}.}
 
 \item{rmd_dir}{Character. Path to directory containing example \verb{\\.Rmd} files
 used to derive titles and order. Default is \code{"inst/examples"}.}
+
+\item{debug}{Logical. Whether to show debug messages. Default is \code{FALSE}.}
 }
 \value{
 \code{NULL} invisibly.

--- a/man/list_non_index_html.Rd
+++ b/man/list_non_index_html.Rd
@@ -4,10 +4,12 @@
 \alias{list_non_index_html}
 \title{List HTML files excluding index.html}
 \usage{
-list_non_index_html(examples_dir)
+list_non_index_html(examples_dir, debug = FALSE)
 }
 \arguments{
 \item{examples_dir}{Character. Path to directory containing example HTML files.}
+
+\item{debug}{Logical. Whether to show debug messages.}
 }
 \value{
 Character vector of HTML file names.

--- a/man/remove_pkgdown_examples.Rd
+++ b/man/remove_pkgdown_examples.Rd
@@ -4,12 +4,14 @@
 \alias{remove_pkgdown_examples}
 \title{Remove examples menu from pkgdown YAML}
 \usage{
-remove_pkgdown_examples(pkgdown_yml, examples_dir)
+remove_pkgdown_examples(pkgdown_yml, examples_dir, debug = FALSE)
 }
 \arguments{
 \item{pkgdown_yml}{Character. Path to \verb{_pkgdown.yml}.}
 
 \item{examples_dir}{Character. Path to examples directory.}
+
+\item{debug}{Logical. Whether to show debug messages.}
 }
 \value{
 \code{NULL} invisibly.

--- a/tests/testthat/_snaps/add_pkgdown_examples.md
+++ b/tests/testthat/_snaps/add_pkgdown_examples.md
@@ -21,6 +21,9 @@
     Code
       test_result <- add_pkgdown_examples(empty_dir, test_path("fixtures",
         "_pkgdown.yml"), rmd_dir = NULL)
+    Condition
+      Warning:
+      No HTML files found in <tempdir>
     Message
       No HTML files found in <tempdir>
       YAML written

--- a/tests/testthat/_snaps/add_pkgdown_examples.md
+++ b/tests/testthat/_snaps/add_pkgdown_examples.md
@@ -21,11 +21,7 @@
     Code
       test_result <- add_pkgdown_examples(empty_dir, test_path("fixtures",
         "_pkgdown.yml"), rmd_dir = NULL)
-    Condition
-      Warning:
-      No HTML files found in <tempdir>
     Message
-      No HTML files found in <tempdir>
       YAML written
       Removed examples menu from 'fixtures/_pkgdown.yml'.
 


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
The latest PR switched to relying on `fs` instead of base functionality. This means there are more errors when there are missing directories and files. 

This causes the pkgdown_with_examples.yaml GHA to fail if there are no examples to include in the pkgdown site. We want this to fail more gracefully and provide a warning, but not be a fatal error. This branch fixes this issue.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->
I've deployed this branch on this [PR ](https://github.com/Gilead-BioStats/gsm.mapping/pull/119)in gsm.mapping and it appears to have solved the issue.

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #XXX
