### PR TITLE
Allow users to pass in a specific gsm.utils version to install

### DIFF
--- a/.github/workflows/pkgdown-core.yaml
+++ b/.github/workflows/pkgdown-core.yaml
@@ -16,6 +16,10 @@ on:
         description: "Whether pkgdown should operate in dev mode."
         type: boolean
         default: false
+      utils-ref:
+        description: "Ref for gsm.utils to install"
+        type: string
+        default: '@dev'
     secrets:
       token:
         description: "GitHub token, set to secrets.GITHUB_TOKEN"
@@ -41,7 +45,7 @@ jobs:
           token: ${{ secrets.token || github.token }}
           r-version: release
           needs: website
-          extra-packages: any::pkgdown gilead-biostats/gsm.utils@dev local::.
+          extra-packages: any::pkgdown gilead-biostats/gsm.utils${{ inputs.utils-ref }} local::.
           cache-version: '1'
       - name: Build and deploy site
         uses: gilead-biostats/gsm.utils/pkgdown-deploy@actions-v1


### PR DESCRIPTION
## Overview
Allow users to pass in a specific gsm.utils version to install, to allow us to test updates to gsm.utils functions that are used during pkgdown build.

## Test Notes/Sample Code
Tested in Gilead-BioStats/gsm.endpoints#291