### PR TITLE
Run R-CMD-check on merge to main/dev for use in badges

### DIFF
--- a/gha_version.json
+++ b/gha_version.json
@@ -3,7 +3,7 @@
     {
       "name": "R-CMD-check.yaml",
       "description": "R CMD check for PRs",
-      "version": "0.3.7"
+      "version": "0.3.8"
     },
     {
       "name": "pkgdown-all.yaml",

--- a/workflow_templates/R-CMD-check.yaml
+++ b/workflow_templates/R-CMD-check.yaml
@@ -1,8 +1,10 @@
 # name: R-CMD-check.yaml
-# version: 0.3.7
+# version: 0.3.8
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Description: R CMD check for PRs
 on:
+  push:
+    branches: [main, dev]
   pull_request:
     branches: [main, dev]
 name: R-CMD-check


### PR DESCRIPTION
## Overview
Run R-CMD-check on merge to main/dev for use in badges. This way the badge can link to the branch, not the most recent run.