### PR TITLE
Fix 118: Choose branch for dispatch

### DIFF
--- a/.github/workflows/pkgdown-core.yaml
+++ b/.github/workflows/pkgdown-core.yaml
@@ -63,6 +63,7 @@ jobs:
           event-name: ${{ inputs.pr-number && 'pull_request' || github.event_name }}
           pr-number: ${{ inputs.pr-number || github.event.number }}
           pkgdown-dev-mode: ${{ inputs.pkgdown-dev-mode == true || (github.event_name != 'workflow_dispatch' && github.ref_name != 'main') }}
+          is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
   clean-pr-preview:
     if: |
       (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository) ||

--- a/.github/workflows/pkgdown-core.yaml
+++ b/.github/workflows/pkgdown-core.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Determine checkout ref
         id: get-ref
         if: inputs.event-name == 'workflow_dispatch'
-        uses: gilead-biostats/gsm.utils/determine-ref@actions-v1
+        uses: gilead-biostats/gsm.utils/determine-ref@determine-ref
         with:
           pr-number: ${{ inputs.pr-number }}
           token: ${{ secrets.token || github.token }}

--- a/.github/workflows/pkgdown-core.yaml
+++ b/.github/workflows/pkgdown-core.yaml
@@ -37,8 +37,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Determine checkout ref
+        id: get-ref
+        if: inputs.event-name == 'workflow_dispatch'
+        uses: gilead-biostats/gsm.utils/determine-ref@actions-v1
+        with:
+          pr-number: ${{ inputs.pr-number }}
+          token: ${{ secrets.token || github.token }}
       - name: Check out repo
         uses: gilead-biostats/gsm.utils/checkout@actions-v1
+        with:
+          ref: ${{ steps.get-ref.outputs.ref }}
       - name: Install R and dependencies
         uses: gilead-biostats/gsm.utils/install@actions-v1
         with:

--- a/.github/workflows/pkgdown-core.yaml
+++ b/.github/workflows/pkgdown-core.yaml
@@ -57,7 +57,7 @@ jobs:
           extra-packages: any::pkgdown gilead-biostats/gsm.utils${{ inputs.utils-ref }} local::.
           cache-version: '1'
       - name: Build and deploy site
-        uses: gilead-biostats/gsm.utils/pkgdown-deploy@actions-v1
+        uses: gilead-biostats/gsm.utils/pkgdown-deploy@fix-118-determine-ref
         with:
           token: ${{ secrets.token || github.token }}
           event-name: ${{ inputs.pr-number && 'pull_request' || github.event_name }}

--- a/.github/workflows/pkgdown-core.yaml
+++ b/.github/workflows/pkgdown-core.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Determine checkout ref
         id: get-ref
         if: inputs.event-name == 'workflow_dispatch'
-        uses: gilead-biostats/gsm.utils/determine-ref@determine-ref
+        uses: gilead-biostats/gsm.utils/determine-ref@fix-118-determine-ref
         with:
           pr-number: ${{ inputs.pr-number }}
           token: ${{ secrets.token || github.token }}

--- a/.github/workflows/pkgdown-core.yaml
+++ b/.github/workflows/pkgdown-core.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Determine checkout ref
         id: get-ref
         if: inputs.event-name == 'workflow_dispatch'
-        uses: gilead-biostats/gsm.utils/determine-ref@fix-118-determine-ref
+        uses: gilead-biostats/gsm.utils/determine-ref@actions-v1
         with:
           pr-number: ${{ inputs.pr-number }}
           token: ${{ secrets.token || github.token }}
@@ -57,7 +57,7 @@ jobs:
           extra-packages: any::pkgdown gilead-biostats/gsm.utils${{ inputs.utils-ref }} local::.
           cache-version: '1'
       - name: Build and deploy site
-        uses: gilead-biostats/gsm.utils/pkgdown-deploy@fix-118-determine-ref
+        uses: gilead-biostats/gsm.utils/pkgdown-deploy@actions-v1
         with:
           token: ${{ secrets.token || github.token }}
           event-name: ${{ inputs.pr-number && 'pull_request' || github.event_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ po/*~
 rsconnect/
 
 /.quarto/
+.positai

--- a/determine-ref/action.yml
+++ b/determine-ref/action.yml
@@ -1,0 +1,39 @@
+name: Determine checkout ref
+description: >
+  Determines the git ref to check out based on a PR number or release tag.
+inputs:
+  pr-number:
+    description: PR number to check out (leave blank for none).
+    required: false
+    default: ''
+  tag:
+    description: Release tag to check out (leave blank for none).
+    required: false
+    default: ''
+  token:
+    description: GitHub token. Used to translate PR number to HEAD ref.
+    required: false
+    default: ${{ github.token }}
+outputs:
+  ref:
+    description: The git ref to check out.
+    value: ${{ steps.get-ref.outputs.ref }}
+runs:
+  using: "composite"
+  steps:
+    - name: Determine checkout ref
+      id: get-ref
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.pr-number }}" ]; then
+          if ! [[ "${{ inputs.pr-number }}" =~ ^[0-9]+$ ]]; then
+            echo "Error: pr-number must contain only digits."
+            exit 1
+          fi
+          ref=$(gh pr view ${{ inputs.pr-number }} --repo ${{ github.repository }} --json headRefName --jq '.headRefName')
+          echo "ref=$ref" >> $GITHUB_OUTPUT
+        elif [ -n "${{ inputs.tag }}" ]; then
+          echo "ref=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+        fi

--- a/pkgdown-deploy/action.yml
+++ b/pkgdown-deploy/action.yml
@@ -60,7 +60,7 @@ runs:
       run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
       shell: Rscript {0}
     - name: Deploy PR preview 🧪
-      uses: gilead-biostats/gsm.utils/pkgdown-pr_preview@actions-v1
+      uses: gilead-biostats/gsm.utils/pkgdown-pr_preview@fix-118-determine-ref
       with:
         repository-name: ${{ inputs.repository-name }}
         repository-owner: ${{ inputs.repository-owner }}

--- a/pkgdown-deploy/action.yml
+++ b/pkgdown-deploy/action.yml
@@ -60,7 +60,7 @@ runs:
       run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
       shell: Rscript {0}
     - name: Deploy PR preview 🧪
-      uses: gilead-biostats/gsm.utils/pkgdown-pr_preview@fix-118-determine-ref
+      uses: gilead-biostats/gsm.utils/pkgdown-pr_preview@actions-v1
       with:
         repository-name: ${{ inputs.repository-name }}
         repository-owner: ${{ inputs.repository-owner }}

--- a/pkgdown-pr_preview/action.yml
+++ b/pkgdown-pr_preview/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - name: Deploy PR preview 🧪
-      if: inputs.event-name == 'pull_request' && inputs.is-fork == 'false'
+      if: (inputs.event-name == 'pull_request' && inputs.is-fork == 'false') || (inputs.event-name == 'workflow_dispatch' && inputs.pr-number != '')
       uses: JamesIves/github-pages-deploy-action@v4.8.0
       with:
         token: ${{ inputs.token }}
@@ -41,7 +41,7 @@ runs:
         target-folder: pr/${{ inputs.pr-number }}
     - name: PR site URL 🌐
       id: site-url
-      if: inputs.event-name == 'pull_request' && inputs.is-fork == 'false'
+      if: (inputs.event-name == 'pull_request' && inputs.is-fork == 'false') || (inputs.event-name == 'workflow_dispatch' && inputs.pr-number != '')
       shell: bash
       run: |
         DEV_SUFFIX=""
@@ -52,7 +52,7 @@ runs:
         echo "url=$SITE_URL" >> $GITHUB_OUTPUT
         echo "🌐 URL: $SITE_URL"
     - name: Comment with PR site URL 🌐
-      if: inputs.event-name == 'pull_request' && inputs.is-fork == 'false'
+      if: (inputs.event-name == 'pull_request' && inputs.is-fork == 'false') || (inputs.event-name == 'workflow_dispatch' && inputs.pr-number != '')
       uses: gilead-biostats/gsm.utils/comment-pr@actions-v1
       with:
         comment-id: 'pkgdown-preview-url'


### PR DESCRIPTION
## Overview
Adds a new composable action, `determine-ref`. Run this conditionally to figure out the GitHub ref associated with a PR or release tag (not necessarily the branch from which the action was initiated).

## Test Notes/Sample Code
Testing in #120 .

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #118 
