### PR TITLE
Fix 106: Full paths to actions

### DIFF
--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -1,0 +1,62 @@
+# name: qcthat.yaml
+# version: 0.1.0
+# Description: Generate qcthat quality control reports for pull requests and releases and manage user acceptance testing.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, milestoned]
+  release:
+    types: [released]
+  issues:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: PR number to which reports should be added (leave blank for none).
+      milestone:
+        description: Milestone name to use to target the milestone report (leave blank for none).
+      tag:
+        description: Release tag to which the report should be attached (leave blank for none).
+      qcthat-ref:
+        description: A specific qcthat GitHub reference, such as a tag ("@v1.0.0"), branch ("@dev"), commit ("@480c247"), or pull request number ("#312") to use for reports and UAT management. Defaults to the latest release, "@*release".
+      issue-number:
+        description: The closed issue number to process to update user acceptance testing information.
+
+name: qcthat
+
+permissions:
+  # read: Required for generating reports and updating UAT status.
+  # write: Required for initiating the UAT process.
+  issues: write
+  # read: Required for updating UAT status.
+  # write: Required for adding reports to pull requests.
+  pull-requests: write
+  # write: Required for attaching reports to releases.
+  contents: write
+  # write: Required for updating UAT status.
+  actions: write
+
+jobs:
+  qcthat:
+    if: >-
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
+      github.event_name != 'issues'
+    uses: Gilead-BioStats/qcthat/.github/workflows/qcthat-core.yaml@actions
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      # Configuration variables for controlling workflow behavior
+      manage-uat: true
+      generate-pr-report: true
+      generate-completed-report: true
+      generate-milestone-report: true
+      generate-release-report: true
+      fail-for-test-failures: true
+      fail-for-missing-tests: true
+      uat-assignees: ${{ (github.event_name == 'pull_request' && github.base_ref == 'main' && 'jwildfire') || (github.event_name == 'pull_request' && github.base_ref != 'main' && 'lauramaxwell,nandriychuk') || '' }}
+      # Event context passed through to the core workflow
+      has-uat-label: ${{ contains(github.event.issue.labels.*.name, 'qcthat-uat') }}
+      pr-number: ${{ github.event.pull_request.number || inputs.pr-number || '' }}
+      milestone: ${{ github.event.pull_request.milestone.title || inputs.milestone || '' }}
+      tag: ${{ github.event.release.tag_name || inputs.tag || '' }}
+      issue-number: ${{ github.event.issue.number || inputs.issue-number || '' }}
+      qcthat-ref: ${{ inputs.qcthat-ref || '@*release' }}

--- a/R/actions.R
+++ b/R/actions.R
@@ -3,7 +3,7 @@
   "https://raw.githubusercontent.com",
   "Gilead-BioStats",
   "gsm.utils",
-  "full-manifest-for-106",
+  "actions-v1",
   "gha_version.json",
   sep = "/"
 )

--- a/R/actions.R
+++ b/R/actions.R
@@ -1,18 +1,32 @@
-# Update this when we move the source repo for actions (and, eventually, issue
-# templates, probably)
-.base_url <- paste(
+# Update this when the manifest moves to a new branch or repo.
+.manifest_url <- paste(
   "https://raw.githubusercontent.com",
   "Gilead-BioStats",
   "gsm.utils",
-  "actions-v1",
+  "full-manifest-for-106",
+  "gha_version.json",
   sep = "/"
 )
 
+# Build a raw content URL for one workflow file. path_extra is omitted when
+# NULL, NA, or empty (e.g. workflows that live at the repo root).
+.workflow_url <- function(name, repo, ref, path_extra = NULL) {
+  parts <- c(
+    "https://raw.githubusercontent.com",
+    repo,
+    ref,
+    if (!is.null(path_extra) && !is.na(path_extra) && nzchar(path_extra)) {
+      path_extra
+    },
+    name
+  )
+  paste(parts, collapse = "/")
+}
+
 #' Add Gilead GitHub Actions to package
 #'
-#' Add the official Gilead GitHub Actions from
-#' <https://github.com/Gilead-BioStats/gsm.utils@actions-v1> to a package, and
-#' update existing Gilead GitHub Actions to the latest versions if necessary.
+#' Add the official Gilead GitHub Actions to a package, and update existing
+#' Gilead GitHub Actions to the latest versions if necessary.
 #'
 #' @inheritParams .shared-params
 #' @returns A character vector of added and updated action names, invisibly.
@@ -28,10 +42,13 @@ add_actions <- function(
     .ensure_dir_exists(workflows_path)
     results <- purrr::pmap(
       manifest,
-      function(name, description, version) {
+      function(name, version, repo, ref, path_extra = NULL, ...) {
         add_action(
           name,
           version,
+          repo = repo,
+          ref = ref,
+          path_extra = path_extra,
           workflows_path = workflows_path,
           overwrite = overwrite,
           verbose = verbose
@@ -61,18 +78,21 @@ add_actions <- function(
 }
 
 .read_github_manifest <- function() {
-  manifest_path <- paste(.base_url, "gha_version.json", sep = "/")
-  manifest <- jsonlite::fromJSON(manifest_path, simplifyVector = TRUE)
+  jsonlite::fromJSON(.manifest_url, simplifyVector = TRUE)
 }
 
 #' Add a Gilead GitHub Action to package
 #'
-#' Add an official Gilead GitHub Action from
-#' <https://github.com/Gilead-BioStats/gsm.utils@actions-v1> to a package, or
-#' update an existing Gilead GitHub Actions to the latest version if necessary.
+#' Add an official Gilead GitHub Action to a package, or update an existing
+#' Gilead GitHub Action to the latest version if necessary. The source location
+#' is determined by the manifest fields `repo`, `ref`, and `path_extra`.
 #'
 #' @param name (`string`) The action to install.
 #' @param version (`string`) The expected version of the action.
+#' @param repo (`string`) GitHub repository in `owner/repo` form.
+#' @param ref (`string`) Git ref (branch, tag, or SHA) in `repo`.
+#' @param path_extra (`string` or `NULL`) Optional subdirectory within the ref
+#'   where the workflow file lives.
 #' @param workflows_path (`string`) Path to the package workflows.
 #' @inheritParams .shared-params
 #' @inheritParams rlang::args_dots_empty
@@ -83,7 +103,10 @@ add_actions <- function(
 add_action <- function(
   name,
   version,
+  repo,
+  ref,
   ...,
+  path_extra = NULL,
   workflows_path = "./.github/workflows",
   overwrite = TRUE,
   verbose = TRUE
@@ -101,7 +124,13 @@ add_action <- function(
         "Creating or updating workflow file {.file {workflow_path}}."
       )
     }
-    return(.update_workflow(name, workflow_path))
+    return(.update_workflow(
+      name,
+      workflow_path,
+      repo = repo,
+      ref = ref,
+      path_extra = path_extra
+    ))
   }
   return(character())
 }
@@ -124,17 +153,33 @@ add_action <- function(
     isTRUE(name == existing_name)
 }
 
-.update_workflow <- function(name, workflow_path) {
-  workflow_contents <- .read_workflow_template(name)
-  # Use unlink instead of fs here because unlink doens't care if the file
+.update_workflow <- function(
+  name,
+  workflow_path,
+  repo,
+  ref,
+  path_extra = NULL
+) {
+  workflow_contents <- .read_workflow_template(
+    name,
+    repo = repo,
+    ref = ref,
+    path_extra = path_extra
+  )
+  # Use unlink instead of fs here because unlink doesn't care if the file
   # exists.
   unlink(workflow_path)
   writeLines(workflow_contents, workflow_path)
   return(name)
 }
 
-.read_workflow_template <- function(name) {
-  workflow_url <- paste(.base_url, "workflow_templates", name, sep = "/")
+.read_workflow_template <- function(name, repo, ref, path_extra = NULL) {
+  workflow_url <- .workflow_url(
+    name,
+    repo = repo,
+    ref = ref,
+    path_extra = path_extra
+  )
   readLines(workflow_url)
 }
 

--- a/man/add_action.Rd
+++ b/man/add_action.Rd
@@ -7,7 +7,10 @@
 add_action(
   name,
   version,
+  repo,
+  ref,
   ...,
+  path_extra = NULL,
   workflows_path = "./.github/workflows",
   overwrite = TRUE,
   verbose = TRUE
@@ -18,7 +21,14 @@ add_action(
 
 \item{version}{(\code{string}) The expected version of the action.}
 
+\item{repo}{(\code{string}) GitHub repository in \code{owner/repo} form.}
+
+\item{ref}{(\code{string}) Git ref (branch, tag, or SHA) in \code{repo}.}
+
 \item{...}{These dots are for future extensions and must be empty.}
+
+\item{path_extra}{(\code{string} or \code{NULL}) Optional subdirectory within the ref
+where the workflow file lives.}
 
 \item{workflows_path}{(\code{string}) Path to the package workflows.}
 
@@ -31,7 +41,7 @@ The name of the workflow if it was updated, otherwise an empty
 character vector.
 }
 \description{
-Add an official Gilead GitHub Action from
-\url{https://github.com/Gilead-BioStats/gsm.utils@actions-v1} to a package, or
-update an existing Gilead GitHub Actions to the latest version if necessary.
+Add an official Gilead GitHub Action to a package, or update an existing
+Gilead GitHub Action to the latest version if necessary. The source location
+is determined by the manifest fields \code{repo}, \code{ref}, and \code{path_extra}.
 }

--- a/man/add_actions.Rd
+++ b/man/add_actions.Rd
@@ -17,7 +17,6 @@ add_actions(strPackageDir = ".", overwrite = TRUE, verbose = TRUE)
 A character vector of added and updated action names, invisibly.
 }
 \description{
-Add the official Gilead GitHub Actions from
-\url{https://github.com/Gilead-BioStats/gsm.utils@actions-v1} to a package, and
-update existing Gilead GitHub Actions to the latest versions if necessary.
+Add the official Gilead GitHub Actions to a package, and update existing
+Gilead GitHub Actions to the latest versions if necessary.
 }

--- a/tests/testthat/fixtures/actions/gha_version.json
+++ b/tests/testthat/fixtures/actions/gha_version.json
@@ -3,17 +3,33 @@
     {
       "name": "action1.yaml",
       "description": "Description 1",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "repo": "Gilead-BioStats/gsm.utils",
+      "ref": "actions-v1",
+      "path_extra": "workflow_templates"
     },
     {
       "name": "action2.yaml",
       "description": "Description 2",
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "repo": "Gilead-BioStats/gsm.utils",
+      "ref": "actions-v1",
+      "path_extra": "workflow_templates"
     },
     {
       "name": "action3.yaml",
       "description": "Description 3",
-      "version": "3.3.3"
+      "version": "3.3.3",
+      "repo": "Gilead-BioStats/gsm.utils",
+      "ref": "actions-v1",
+      "path_extra": "workflow_templates"
+    },
+    {
+      "name": "action-external.yaml",
+      "description": "External repo action without path_extra",
+      "version": "0.1.0",
+      "repo": "Gilead-BioStats/other-pkg",
+      "ref": "actions"
     }
   ]
 }

--- a/tests/testthat/test-actions.R
+++ b/tests/testthat/test-actions.R
@@ -59,7 +59,7 @@ test_that("add_actions informs when nothing added (#90)", {
 
 ## add_action ----
 
-test_that("action helpers work (#90)", {
+test_that("action helpers work (#90, #106)", {
   local_mocked_bindings(
     .manifest_url = test_path("fixtures/actions/gha_version.json")
   )
@@ -100,6 +100,15 @@ test_that(".workflow_url constructs URLs correctly (#106)", {
       repo = "Gilead-BioStats/qcthat",
       ref = "actions",
       path_extra = NA
+    ),
+    "https://raw.githubusercontent.com/Gilead-BioStats/qcthat/actions/qcthat.yaml"
+  )
+  expect_equal(
+    .workflow_url(
+      "qcthat.yaml",
+      repo = "Gilead-BioStats/qcthat",
+      ref = "actions",
+      path_extra = ""
     ),
     "https://raw.githubusercontent.com/Gilead-BioStats/qcthat/actions/qcthat.yaml"
   )

--- a/tests/testthat/test-actions.R
+++ b/tests/testthat/test-actions.R
@@ -18,17 +18,14 @@ test_that("add_actions adds each action in the manifest (#90)", {
       data.frame(
         name = c("action1.yaml", "action2.yaml", "action3.yaml"),
         description = "This isn't used yet so I'm repeating",
-        version = c("1.0.0", "2.2.0", "3.3.3")
+        version = c("1.0.0", "2.2.0", "3.3.3"),
+        repo = "Gilead-BioStats/gsm.utils",
+        ref = "actions-v1",
+        path_extra = "workflow_templates"
       )
     },
     .ensure_dir_exists = function(path) path,
-    add_action = function(
-      name,
-      version,
-      workflows_path,
-      overwrite,
-      verbose
-    ) {
+    add_action = function(name, version, ...) {
       cli::cli_inform("installing {name} v{version}")
       name
     }
@@ -46,7 +43,10 @@ test_that("add_actions informs when nothing added (#90)", {
       data.frame(
         name = c("action1.yaml", "action2.yaml", "action3.yaml"),
         description = "This isn't used yet so I'm repeating",
-        version = c("1.0.0", "2.2.0", "3.3.3")
+        version = c("1.0.0", "2.2.0", "3.3.3"),
+        repo = "Gilead-BioStats/gsm.utils",
+        ref = "actions-v1",
+        path_extra = "workflow_templates"
       )
     },
     .ensure_dir_exists = function(path) path,
@@ -61,7 +61,7 @@ test_that("add_actions informs when nothing added (#90)", {
 
 test_that("action helpers work (#90)", {
   local_mocked_bindings(
-    .base_url = test_path("fixtures/actions")
+    .manifest_url = test_path("fixtures/actions/gha_version.json")
   )
   manifest_all <- .read_github_manifest()
   expect_named(manifest_all, "workflows")
@@ -69,18 +69,43 @@ test_that("action helpers work (#90)", {
   expect_s3_class(manifest_workflows, "data.frame")
   expect_equal(
     colnames(manifest_workflows),
-    c("name", "description", "version")
+    c("name", "description", "version", "repo", "ref", "path_extra")
   )
-  action1 <- .read_workflow_template("action1.yaml")
+})
+
+test_that(".workflow_url constructs URLs correctly (#106)", {
+  # with path_extra
   expect_equal(
-    action1,
-    c(
-      "# name: action1.yaml",
-      "# version: 1.0.0",
-      "# Description: Description 1",
-      "Contents of action 1 v1.0.0"
-    )
+    .workflow_url(
+      "R-CMD-check.yaml",
+      repo = "Gilead-BioStats/gsm.utils",
+      ref = "actions-v1",
+      path_extra = "workflow_templates"
+    ),
+    "https://raw.githubusercontent.com/Gilead-BioStats/gsm.utils/actions-v1/workflow_templates/R-CMD-check.yaml"
   )
+  # without path_extra (NULL, NA, or empty string all omit it)
+  expect_equal(
+    .workflow_url(
+      "qcthat.yaml",
+      repo = "Gilead-BioStats/qcthat",
+      ref = "actions",
+      path_extra = NULL
+    ),
+    "https://raw.githubusercontent.com/Gilead-BioStats/qcthat/actions/qcthat.yaml"
+  )
+  expect_equal(
+    .workflow_url(
+      "qcthat.yaml",
+      repo = "Gilead-BioStats/qcthat",
+      ref = "actions",
+      path_extra = NA
+    ),
+    "https://raw.githubusercontent.com/Gilead-BioStats/qcthat/actions/qcthat.yaml"
+  )
+})
+
+test_that(".workflow_up_to_date works (#90)", {
   expect_true(.workflow_up_to_date(
     "action1.yaml",
     "1.0.0",
@@ -98,6 +123,29 @@ test_that("action helpers work (#90)", {
   ))
 })
 
+test_that(".read_workflow_template reads from correct URL (#106)", {
+  local_mocked_bindings(
+    .workflow_url = function(...) {
+      test_path("fixtures/actions/workflow_templates/action1.yaml")
+    }
+  )
+  action1 <- .read_workflow_template(
+    "action1.yaml",
+    repo = "Gilead-BioStats/gsm.utils",
+    ref = "actions-v1",
+    path_extra = "workflow_templates"
+  )
+  expect_equal(
+    action1,
+    c(
+      "# name: action1.yaml",
+      "# version: 1.0.0",
+      "# Description: Description 1",
+      "Contents of action 1 v1.0.0"
+    )
+  )
+})
+
 test_that("add_action errors when workflow needs an update but overwrite is FALSE (#90)", {
   local_mocked_bindings(
     .workflow_up_to_date = function(...) FALSE
@@ -105,6 +153,9 @@ test_that("add_action errors when workflow needs an update but overwrite is FALS
   add_action(
     "action1.yaml",
     "2.0.0",
+    repo = "Gilead-BioStats/gsm.utils",
+    ref = "actions-v1",
+    path_extra = "workflow_templates",
     workflows_path = test_path("fixtures/actions/installed_workflows"),
     overwrite = FALSE
   ) |>
@@ -119,6 +170,8 @@ test_that("add_action returns an empty vector when workflow is already up-to-dat
     add_action(
       "action1.yaml",
       "2.0.0",
+      repo = "Gilead-BioStats/gsm.utils",
+      ref = "actions-v1",
       workflows_path = test_path("fixtures/actions/installed_workflows")
     ),
     character()
@@ -128,11 +181,13 @@ test_that("add_action returns an empty vector when workflow is already up-to-dat
 test_that("add_action informs when verbose is TRUE (#90)", {
   local_mocked_bindings(
     .workflow_up_to_date = function(...) FALSE,
-    .update_workflow = function(name, workflow_path) name
+    .update_workflow = function(name, workflow_path, ...) name
   )
   add_action(
     "action1.yaml",
     "2.0.0",
+    repo = "Gilead-BioStats/gsm.utils",
+    ref = "actions-v1",
     workflows_path = test_path("fixtures/actions/installed_workflows")
   ) |>
     expect_message("Creating or updating workflow file .+")
@@ -147,6 +202,8 @@ test_that("add_action updates when appropriate (#90)", {
   add_action(
     "action1.yaml",
     "2.0.0",
+    repo = "Gilead-BioStats/gsm.utils",
+    ref = "actions-v1",
     workflows_path = workflows_path
   ) |>
     expect_equal("action1.yaml") |>


### PR DESCRIPTION
## Overview
Update `add_actions()` (etc) to use new, expanded manifest from #122. 

## Test Notes/Sample Code

Find/replace "full-manifest-for-106" with "actions-v1" after #122 is merged.

## Connected Issues

- Closes #106
- Closes #28