### PR TITLE
Fix-125-use-releaesed-utils

### DIFF
--- a/.github/workflows/pkgdown-core.yaml
+++ b/.github/workflows/pkgdown-core.yaml
@@ -19,7 +19,7 @@ on:
       utils-ref:
         description: "Ref for gsm.utils to install"
         type: string
-        default: '@dev'
+        default: '@*release'
     secrets:
       token:
         description: "GitHub token, set to secrets.GITHUB_TOKEN"

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: "GitHub token (usually secrets.GITHUB_TOKEN)"
     required: true
     default: ${{ github.token }}
+  utils-ref:
+    description: "Ref for gsm.utils to install"
+    default: '@*release'
 
 runs:
   using: "composite"
@@ -17,7 +20,7 @@ runs:
       uses: gilead-biostats/gsm.utils/install@actions-v1
       with:
         token: ${{ inputs.token }}
-        extra-packages: any::covr any::xml2 any::jsonlite gilead-bioStats/gsm.utils@dev local::.
+        extra-packages: any::covr any::xml2 any::jsonlite gilead-biostats/gsm.utils${{ inputs.utils-ref }} local::.
         needs: coverage
 
     - name: Compute coverage


### PR DESCRIPTION
## Overview
Update pkgdown-core variable to point to the released version of gsm.utils by default, and update the coverage action to use the same technique (it was previously hard-coded to install the dev version).

## Test Notes/Sample Code
This can't be merged until after #126.

## Connected Issues

- Closes #125
